### PR TITLE
Bump version to support Pg16.  Dropping pg11.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg15"]
-pg11 = ["pgrx/pg11", "pgrx-tests/pg11" ]
+default = ["pg16"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.5"
+pgrx = "=0.10.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.5"
+pgrx-tests = "=0.10.1"
 
 [profile.dev]
 panic = "unwind"


### PR DESCRIPTION
No functional changes, just keeping up with version lifecycles. Tagging for next version, but functional as 0.0.3.