### PR TITLE
Update to pgrx 0.12.0.alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "convert"
-version = "0.0.3"
+version = "0.0.4-dev.1"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [features]
 default = ["pg16"]
@@ -16,10 +16,10 @@ pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.10.1"
+pgrx = "=0.12.0-alpha.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.10.1"
+pgrx-tests = "=0.12.0-alpha.1"
 
 [profile.dev]
 panic = "unwind"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 Ryan Lambert, RustProof Labs
+Copyright (c) 2022-2024 Ryan Lambert, RustProof Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ rm ${OUTFILE} || true
 fpm \
   -s dir \
   -t deb -n convert \
-  -v 0.0.2 \
+  -v 0.0.4-dev.1 \
   --deb-no-default-config-files \
   -p ${OUTFILE} \
   -a amd64 \

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,7 +1,7 @@
 # Based on PgDD https://github.com/rustprooflabs/pgdd/tree/main/build
 # which was original based on ZomboDB's system.
 #
-# Copyright 2023-2023 RustProof Labs
+# Copyright 2023-2024 RustProof Labs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ BASE=$(dirname `pwd`)
 VERSION=$(cat $BASE/convert.control | grep default_version | cut -f2 -d\')
 LOGDIR=${BASE}/target/logs
 ARTIFACTDIR=${BASE}/target/artifacts
-PGRXVERSION=0.10.1
+PGRXVERSION=0.12.0-alpha.1
 
 #PG_VERS=("pg12" "pg13" "pg14" "pg15" "pg16")
 PG_VERS=("pg16")

--- a/build/package.sh
+++ b/build/package.sh
@@ -1,6 +1,6 @@
 # Borrowed heavily from https://github.com/zombodb/zombodb/blob/master/build/package.sh
 #
-# Copyright 2021-2023 RustProof Labs
+# Copyright 2021-2024 RustProof Labs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/convert.control
+++ b/convert.control
@@ -1,5 +1,5 @@
 comment = 'Helpful conversion functions for spatial, routing and other specialized uses: Created with pgrx by RustProof Labs'
-default_version = '0.0.3'
+default_version = '0.0.4-dev.1'
 module_pathname = '$libdir/convert'
 relocatable = false
 superuser = false

--- a/src/bin/pgrx_embed_convert.rs
+++ b/src/bin/pgrx_embed_convert.rs
@@ -1,0 +1,2 @@
+// Required for pgrx v0.12.0.alpha.1
+::pgrx::pgrx_embed!();


### PR DESCRIPTION
Update to [pgrx v0.12.0.alpha.1](https://github.com/pgcentralfoundation/pgrx/releases/tag/v0.12.0-alpha.1).