### PR TITLE
Pg18 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17" ]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.14.1"
+pgrx = "=0.16.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.14.1"
+pgrx-tests = "=0.16.1"
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "convert"
-version = "0.0.4"
-edition = "2021"
+version = "0.0.5"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "lib"]
 
 [features]
-default = ["pg17"]
-pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
+default = ["pg18"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]

--- a/build/build.sh
+++ b/build/build.sh
@@ -22,10 +22,10 @@ BASE=$(dirname `pwd`)
 VERSION=$(cat $BASE/convert.control | grep default_version | cut -f2 -d\')
 LOGDIR=${BASE}/target/logs
 ARTIFACTDIR=${BASE}/target/artifacts
-PGRXVERSION=0.14.1
+PGRXVERSION=0.16.1
 
-PG_VERS=("pg13" "pg14" "pg15" "pg16" "pg17")
-#PG_VERS=("pg17")
+PG_VERS=("pg14" "pg15" "pg16" "pg17" "pg18")
+#PG_VERS=("pg18")
 
 echo $BASE
 echo $VERSION

--- a/build/docker/convert-debian-postgis/Dockerfile
+++ b/build/docker/convert-debian-postgis/Dockerfile
@@ -27,11 +27,11 @@ RUN apt-get install -y --fix-missing \
         libldap-dev libkrb5-dev gettext tcl-tclreadline tcl-dev libperl-dev \
         libpython3-dev libprotobuf-c-dev libprotobuf-dev gcc \
         ruby ruby-dev rubygems \
-        postgresql-13 postgresql-server-dev-13 \
         postgresql-14 postgresql-server-dev-14 \
         postgresql-15 postgresql-server-dev-15 \
         postgresql-16 postgresql-server-dev-16 \
         postgresql-17 postgresql-server-dev-17 \
+        postgresql-18 postgresql-server-dev-18 \
     && apt autoremove -y
 
 

--- a/convert.control
+++ b/convert.control
@@ -1,5 +1,5 @@
 comment = 'Helpful conversion functions for spatial, routing and other specialized uses: Created with pgrx by RustProof Labs'
-default_version = '0.0.4'
+default_version = '0.0.5'
 module_pathname = '$libdir/convert'
 relocatable = false
 superuser = false


### PR DESCRIPTION
Builds on [@vonng](https://github.com/Vonng)'s MR https://github.com/rustprooflabs/convert/pull/11 to update the build process and remove legacy version support.

* Add Postgres 18 support
* Remove Postgres 13 support
* Bump pgrx to 0.16.1 and edition to 2024